### PR TITLE
fix: update Claude 3.7 model ID format for AWS Bedrock cross-region inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Improved error handling for validation exceptions
 - Better handling of API timeouts for large responses
+- Updated model ID format to use the inference profile ID required for AWS Bedrock cross-region inference (`us.anthropic.claude-3-7-sonnet-20250219-v1:0`)
 
 ## [1.2.0] - 2025-05-10
 

--- a/bedrock-client.js
+++ b/bedrock-client.js
@@ -51,7 +51,7 @@ class BedrockClient {
     });
 
     const command = new InvokeModelCommand({
-      modelId: "anthropic.claude-3-7-sonnet-20250219",
+      modelId: "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
       contentType: "application/json",
       accept: "application/json",
       body: JSON.stringify({ 


### PR DESCRIPTION
## Problem
When testing the ClaudeCoder action with AWS Bedrock, we encountered the following error:
```
Warning: Bedrock API call failed. Retrying in 5 seconds... Error: The provided model identifier is invalid.
```

This is because AWS Bedrock now requires using inference profile IDs instead of direct model IDs for cross-region inference.

## Changes
- Updated the model ID in `bedrock-client.js` from `anthropic.claude-3-7-sonnet-20250219` to `us.anthropic.claude-3-7-sonnet-20250219-v1:0`
- Updated the CHANGELOG.md to document this fix

## Testing
- Successfully built the project after making the changes
- The updated model ID format complies with AWS Bedrock's requirements for cross-region inference profiles

## Additional Information
According to AWS documentation, inference profiles are required for cross-region inference, and each model has a specific inference profile ID format. This change ensures that we're using the correct format for Claude 3.7 Sonnet.

Fixes the "The provided model identifier is invalid" error when invoking AWS Bedrock.
