### PR TITLE
Fix: Update thinking budget to meet Bedrock API minimum requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling for validation exceptions
 - Better handling of API timeouts for large responses
 - Updated model ID format to use the inference profile ID required for AWS Bedrock cross-region inference (`us.anthropic.claude-3-7-sonnet-20250219-v1:0`)
+- Updated default thinking budget from 1000 to 1024 tokens to meet Bedrock API minimum requirement
 
 ## [1.2.0] - 2025-05-10
 

--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: 'true'
   thinking-budget:
-    description: 'Token budget for Claude''s thinking process'
+    description: 'Token budget for Claude''s thinking process (minimum: 1024)'
     required: false
-    default: '1000'
+    default: '1024'
   extended-output:
     description: 'Enable 128K extended output capability (true/false)'
     required: false

--- a/bedrock-client.js
+++ b/bedrock-client.js
@@ -6,7 +6,7 @@ class BedrockClient {
     // Initialize configurable parameters with defaults
     this.maxTokens = options.maxTokens || 64000; // Maximum supported is 128K, default to 64K (GA limit)
     this.enableThinking = options.enableThinking !== undefined ? options.enableThinking : true;
-    this.thinkingBudget = options.thinkingBudget || 1000; // Default to 1000 tokens for thinking
+    this.thinkingBudget = options.thinkingBudget || 1024; // Default to 1024 tokens for thinking (API minimum)
     this.extendedOutput = options.extendedOutput !== undefined ? options.extendedOutput : true; // Enable 128K output by default
     this.requestTimeout = options.requestTimeout || 3600000; // Default to 60 minutes (3600000 ms)
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the ClaudeCoder action fails with the following error:
```
Warning: Bedrock API call failed. Retrying in 5 seconds... Error: thinking.enabled.budget_tokens: Input should be greater than or equal to 1024
```

The AWS Bedrock API requires a minimum of 1024 tokens for the thinking budget, but our default was set to 1000 tokens.

## Changes

- Updated the default thinking budget in `bedrock-client.js` from 1000 to 1024 tokens
- Updated the default value for `thinking-budget` in `action.yml` from 1000 to 1024
- Updated the description in `action.yml` to indicate the minimum requirement (1024)
- Updated `CHANGELOG.md` to document this fix

## Testing

Tested by running the action with the updated settings, confirming that the API error is resolved.
